### PR TITLE
React.memo with argument

### DIFF
--- a/src/React/Basic/Hooks.js
+++ b/src/React/Basic/Hooks.js
@@ -13,6 +13,7 @@ const useEqCache = (eq, a) => {
 exports.reactChildrenToArray = (children) => React.Children.toArray(children);
 
 exports.memo_ = React.memo;
+exports.memoEq_ = React.memo;
 
 exports.useState_ = (tuple, initialState) => {
   const r = React.useState(

--- a/src/React/Basic/Hooks.purs
+++ b/src/React/Basic/Hooks.purs
@@ -8,6 +8,7 @@ module React.Basic.Hooks
   , reactChildrenToArray
   , reactChildrenFromArray
   , memo
+  , memo'
   , useState
   , useState'
   , UseState
@@ -165,6 +166,16 @@ memo ::
   Effect (ReactComponent props) ->
   Effect (ReactComponent props)
 memo = flip Prelude.bind (runEffectFn1 memo_)
+
+-- | Similar to `memo` but takes a function to compare previous and new props
+memo' ::
+  forall props.
+  (props -> props -> Boolean) ->
+  Effect (ReactComponent props) ->
+  Effect (ReactComponent props)
+memo' arePropsEqual comp = Prelude.do
+  c <- comp
+  runEffectFn2 memoEq_ c (mkFn2 arePropsEqual)
 
 useState ::
   forall state.
@@ -357,6 +368,13 @@ foreign import memo_ ::
   forall props.
   EffectFn1
     (ReactComponent props)
+    (ReactComponent props)
+
+foreign import memoEq_ ::
+  forall props.
+  EffectFn2
+    (ReactComponent props)
+    (Fn2 props props Boolean)
     (ReactComponent props)
 
 foreign import unsafeSetDisplayName ::


### PR DESCRIPTION
Adding another variant of memo that allows passing a function to compareprevious and new props.

<https://reactjs.org/docs/react-api.html#reactmemo>

I'm open to any name changes and other suggestions.

Solves <https://github.com/megamaddu/purescript-react-basic-hooks/issues/60>